### PR TITLE
Fixing Time Now (UTC) to work with older versions of Python

### DIFF
--- a/src/basic_data_handling/time_nodes.py
+++ b/src/basic_data_handling/time_nodes.py
@@ -81,7 +81,7 @@ class TimeNowUTC(ComfyNodeABC):
         Retrieves the current system time in the UTC timezone.
         The optional trigger input can be used to trigger execution.
         """
-        return (datetime.datetime.now(datetime.UTC),)
+        return (datetime.datetime.now(datetime.timezone.utc),)
 
 
 class TimeToUnix(ComfyNodeABC):


### PR DESCRIPTION
So apparently `datetime.UTC` was added in Python 3.11, but ComfyUI is still using Python 3.10

So this fixes the `Time Now (UTC)` node so it works with older versions of Python.