### PR TITLE
Fix StringListJoin separator handling

### DIFF
--- a/src/basic_data_handling/string_nodes.py
+++ b/src/basic_data_handling/string_nodes.py
@@ -752,8 +752,7 @@ class StringListJoin(ComfyNodeABC):
     FUNCTION = "join"
 
     def join(self, sep, strings):
-        separator = sep[0]    # everything comes as a list, so sep is list[str]
-        return (separator.join(strings),)
+        return (sep.join(strings),)
 
 
 class StringLjust(ComfyNodeABC):

--- a/tests/test_string_nodes.py
+++ b/tests/test_string_nodes.py
@@ -226,9 +226,9 @@ def test_join():
 
     # Test ListJoin variant
     node_list = StringListJoin()
-    assert node_list.join([", "], ["apple", "banana", "cherry"]) == ("apple, banana, cherry",)
-    assert node_list.join([""], ["a", "b", "c"]) == ("abc",)
-    assert node_list.join(["-"], []) == ("",)  # Empty list
+    assert node_list.join(", ", ["apple", "banana", "cherry"]) == ("apple, banana, cherry",)
+    assert node_list.join("", ["a", "b", "c"]) == ("abc",)
+    assert node_list.join("-", []) == ("",)  # Empty list
 
 def test_ljust():
     node = StringLjust()


### PR DESCRIPTION
- Fix `StringListJoin` to use `sep` as a plain string (it does not set `INPUT_IS_LIST`)
- Update tests to pass a string separator instead of a one-element list

Because `sep` was indexed with `[0]`, multi-character separators in the UI were truncated to their first character (e.g. `", "` became `","`).